### PR TITLE
Show full text for first few articles on homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+
+<div class="home">
+  
+  {{ content }}
+
+  <ul class="post-list">
+    {% for post in site.posts limit:5 %}
+      <li>
+        <h2>{{ post.title }}</h2>
+        <div class="post-meta">
+          {{ post.date | date: "%-d.%-m.%-Y" }}
+        </div>
+        <div class="post-content">
+          {{ post.content }}
+        </div>
+
+      </li>
+    {% endfor %}
+  </ul>
+  <h1>Older Posts</h1>
+  <ul class="post-list abbreviated">
+    {% for post in site.posts offset:5 %}
+      <li>
+        <h2>
+          <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+        </h2>
+        <div class="post-meta">
+          {{ post.date | date: "%-d.%-m.%-Y" }}
+        </div>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+
+</div>


### PR DESCRIPTION
Instead of showing just the title, this will show the full text in the post-list as well for the first 5 posts.

Older posts will still be displayed with the title + link to the post only. 

This also updates the date format to the German date format.

See generated preview and compare it to [the current live version](https://cocoaheads.hamburg).